### PR TITLE
Remove 'subtitle and '.js'

### DIFF
--- a/tasks/angular.task.js
+++ b/tasks/angular.task.js
@@ -34,10 +34,9 @@ Elixir.extend('angular', function(src, output, outputFilename) {
 			.pipe(gulp.dest(output || config.js.outputFolder))
 			.pipe(notify({
 				title: 'Laravel Elixir',
-				subtitle: 'Angular Compiled!',
 				icon: __dirname + '/../node_modules/laravel-elixir/icons/laravel.png',
-				message: ' '
+				message: 'Angular Compiled!'
 			}));
-	}).watch(baseDir + '/**/*.js');
+	}).watch(baseDir + '/**/*');
 
 });


### PR DESCRIPTION
The subtitle wasn't showing anywhere, i changed that text to the messages one now notifications show the message correctly

remove the `.js` to really watch everything (folders and files)